### PR TITLE
Switch app.close.io to api.close.com

### DIFF
--- a/lib/Closeio.php
+++ b/lib/Closeio.php
@@ -13,7 +13,7 @@ require(dirname(__FILE__).'/Methods.php');
 require(dirname(__FILE__).'/routes/Lead.php');
 
 define('CLOSEIO_TRANSPORT_PROTOCOL', 'https');
-define('CLOSEIO_HOST', 'app.close.io/api/v1');
+define('CLOSEIO_HOST', 'api.close.com/api/v1');
 if(!defined('CLOSEIO_DEBUG')){
   define('CLOSEIO_DEBUG', false);
 }


### PR DESCRIPTION
Hey there -- 

Eric from Close here! We're changing the base url of our api from app.close.io/api/v1 to api.close.com/api/v1

This PR makes that change for your Repo :) 

app.close.io/api/v1 will continue to be supported, but is now deprecated. 

Thanks! 